### PR TITLE
Feature: Watchtower Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="1.8.0-watchtower"></a>
-# [1.8.0-watchtower](https://github.com/ajgon/opsworks_ruby/compare/v1.8.0...v1.8.0-watchtower)
+# [1.8.0-watchtower](https://github.com/WatchTowerBenefits/opsworks_ruby/compare/v1.8.0...v1.8.0-watchtower)
 
 ### Bug Fixes
 * `libraries/drivers_appswerver_puma.rb`: app_server method updated to not escape template since it was preventing the start of Puma

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+<a name="1.8.0-watchtower"></a>
+# [1.8.0-watchtower](https://github.com/ajgon/opsworks_ruby/compare/v1.8.0...v1.8.0-watchtower)
+
+### Bug Fixes
+* `libraries/drivers_appswerver_puma.rb`: app_server method updated to not escape template since it was preventing the start of Puma
+  * NOTE: This fixes the starting of Puma with rbenv. Have not tried this fix with ruby-ng.
+
+### Features
+* Adding in support to specify `additional_packages` in the OpsWorks custom JSON field, and then install those additional packages during setup
+* Added support for rbenv! Specify `['rbenv']['ruby_version]` in the OpsWorks custom JSON field in order to install rbenv with a specific Ruby version
+  * rbenv support has been added to allow ruby-ng to still be applied in place of rbenv, but has not been tested with the updates
+  * Currently, rbenv support has only been applied to the recipes, and the following libraries and templates:
+    * `libraries/helpers.rb`: Modifies the `perform_bundle_install` command in order to use rbenv when set
+    * `libraries/drivers_appserver_base.rb`: Confirmed working for Puma, not tested with other appservers 
+    * `libraries/drivers_frameworks_base.rb`: Setup to use rbenv for asset compilation when set (have not tested since we are only using this for an API project so far)
+    * `templates/appserver.service.erb`: Updated the start command to modify the bundle path if rbenv is set. This is confirmed to be working for Puma, not tested with other app servers
+
+### Notes
+Some of the code applied in this version seems like it could be DRYed up, specifically the code that reinitializes rbenv each place it is being used.
+This proves slightly difficult since the code for `ruby_rbenv` is available in recipes, but doesn't seem fully supported through the libraries.
+Another spot the code could be improved is at the top of the deploy recipe. We're patching the migrate command to be rbenv aware, and still let the migrate hooks fire.
+Ideally we could pull this out into it's own file, but then we run into the same issue with `ruby_rbenv` availability within that file.
+
+
 <a name="1.8.0"></a>
 # [1.8.0](https://github.com/ajgon/opsworks_ruby/compare/v1.7.1...v1.8.0) (2017-10-23)
 

--- a/README.md
+++ b/README.md
@@ -1,48 +1,29 @@
+# WatchTower Benefits opsworks_ruby Cookbook
+This is a fork of the [opsworks_ruby](https://github.com/ajgon/opsworks_ruby) cookbook, forked at version 1.8.0.
+This cookbook is being used to provision our AWS OpsWorks servers.
+
+## Changes from opsworks_ruby cookbook
+
+### Support installing additional packages via OpsWorks custom JSON
+In order to install additinal packages, simply add an array of packages to your custom JSON as `node['additional_packages']`
+```json
+{
+  "additional_packages": ["libcurl3", "libcurl3-gnutls", "libcurl4-openssl-dev", "zlib1g-dev", "liblzma-dev"] 
+}
+``` 
+
+### Support for using rbenv instead of ruby-ng
+In order to install rbenv, with the Ruby version of your choice, add `node['rbenv']['ruby_version']` to you OpsWorks custom JSON
+```json
+{
+  "rbenv": {
+    "ruby_version": "2.3.6"
+  }
+}
+``` 
+Currently, rbenv support is implemented with Rails as the framework, and Puma as the app server.
+Due to this, if we end up using this recipe for another Ruby framework or we want to switch app servers, we will need to add in support for rbenv in those library files.
+We are currently using nginx as the web server, but no changes were made there, so switching web servers should be straightforward.
+
 # opsworks_ruby Cookbook
-
-[![Chef cookbook](https://img.shields.io/cookbook/v/opsworks_ruby.svg)](https://supermarket.chef.io/cookbooks/opsworks_ruby)
-[![Build Status](https://travis-ci.org/ajgon/opsworks_ruby.svg?branch=master)](https://travis-ci.org/ajgon/opsworks_ruby)
-[![Coverage Status](https://coveralls.io/repos/github/ajgon/opsworks_ruby/badge.svg?branch=master)](https://coveralls.io/github/ajgon/opsworks_ruby?branch=master)
-[![Documentation Status](https://readthedocs.org/projects/opsworks-ruby/badge/?version=latest)](http://opsworks-ruby.readthedocs.io/en/latest/?badge=latest)
-[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
-[![license](https://img.shields.io/github/license/ajgon/opsworks_ruby.svg?maxAge=2592000)](https://opsworks-ruby.mit-license.org/)
-
-A [chef](https://www.chef.io/) cookbook to deploy Ruby applications to Amazon OpsWorks.
-
-## Quick Start
-
-Refer to [Getting Started](http://opsworks-ruby.readthedocs.io/en/latest/getting_started.html)
-guide in [documentation](http://opsworks-ruby.readthedocs.io/en/latest/index.html).
-
-## Development
-
-You can either install eveyrthing locally using [rvm](https://rvm.io/) and [pip](https://pypi.python.org/pypi/pip)
-or use the Docker container which includes all necessary dependencies inside it.
-
-### Build documentation
-
-```
-docker-compose run cookbook bash -c "cd docs && make html"
-```
-
-## Contributing
-
-Please see [CONTRIBUTING](https://github.com/ajgon/opsworks_ruby/blob/master/CONTRIBUTING.md)
-for details.
-
-## Author and Contributors
-
-Author: [Igor Rzegocki](https://www.rzegocki.pl/) ([@ajgon](https://github.com/ajgon))
-
-### Contributors
-
-* Nick Marden ([@nickmarden](https://github.com/nickmarden))
-* Phong Si ([@phongsi](https://github.com/phongsi))
-* Kevin Pheasey ([@kpheasey](https://github.com/kpheasey))
-* Nathan Flood ([@npflood](https://github.com/npflood))
-* Teruo Adachi ([@interu](https://github.com/interu))
-* Marcos Beirigo ([@marcosbeirigo](https://github.com/marcosbeirigo))
-
-## License
-
-License: [MIT](http://opsworks-ruby.mit-license.org/)
+To view the original `opsworks_ruby` cookbook's README at the time we forked this repo, visit [https://github.com/ajgon/opsworks_ruby/blob/v1.8.0/README.md](https://github.com/ajgon/opsworks_ruby/blob/v1.8.0/README.md)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -116,12 +116,26 @@ default['defaults']['framework']['adapter'] = 'rails'
 
 default['defaults']['framework']['migrate'] = true
 default['defaults']['framework']['migration_command'] =
-  'case $(/usr/local/bin/bundle exec rake db:version 2>&1) in ' \
-  '*"ActiveRecord::NoDatabaseError"*) /usr/local/bin/bundle exec rake db:setup;; ' \
-  '*) /usr/local/bin/bundle exec rake db:migrate;; ' \
-  'esac'
+  if node['rbenv']
+    'case $(bundle exec rake db:version 2>&1) in ' \
+    '*"ActiveRecord::NoDatabaseError"*) bundle exec rake db:setup;; ' \
+    '*) bundle exec rake db:migrate;; ' \
+    'esac'
+  else
+    'case $(/usr/local/bin/bundle exec rake db:version 2>&1) in ' \
+    '*"ActiveRecord::NoDatabaseError"*) /usr/local/bin/bundle exec rake db:setup;; ' \
+    '*) /usr/local/bin/bundle exec rake db:migrate;; ' \
+    'esac'
+  end
 default['defaults']['framework']['assets_precompile'] = true
-default['defaults']['framework']['assets_precompilation_command'] = '/usr/local/bin/bundle exec rake assets:precompile'
+default['defaults']['framework']['assets_precompilation_command'] =
+  if node['rbenv']
+    'bundle exec rake assets:precompile'
+  else
+    '/usr/local/bin/bundle exec rake assets:precompile'
+  end
+
+
 default['defaults']['framework']['envs_in_console'] = false
 
 # worker

--- a/libraries/drivers_appserver_puma.rb
+++ b/libraries/drivers_appserver_puma.rb
@@ -12,7 +12,7 @@ module Drivers
       end
 
       def appserver_command
-        'puma -C #\{ROOT_PATH\}/shared/config/puma.rb'
+        'puma -C #{ROOT_PATH}/shared/config/puma.rb'
       end
     end
   end

--- a/libraries/drivers_framework_base.rb
+++ b/libraries/drivers_framework_base.rb
@@ -32,12 +32,46 @@ module Drivers
         deploy_to = deploy_dir(app)
         env = environment.merge('HOME' => node['deployer']['home'])
 
-        context.execute 'assets:precompile' do
-          command output[:assets_precompilation_command]
-          user node['deployer']['user']
-          cwd File.join(deploy_to, 'current')
-          group www_group
-          environment env
+        # Check for rbenv in node object
+        # If it is set, run precompile assets using an rbenv aware script
+        # If not, we proceed as normal
+        if node['rbenv']
+          # Install / initialize an rbenv user with the ruby_version supplied
+          # Since the rbenv environment won't persist to library methods, and there are issues with pulling it out into it's own helper, we currently redefine this in multiple places
+          # Would be nice to DRY this up if possible
+
+          # Install Ruby via rbenv
+          ruby_version = node['rbenv']['ruby_version']
+          deploy_user = node['deployer']['user'] || root
+
+          # Install rbenv for deploy user
+          context.rbenv_user_install(deploy_user)
+
+          # Install a specified ruby_version for deploy user
+          context.rbenv_ruby(ruby_version) do
+            user(deploy_user)
+          end
+
+          # Globally set ruby_version for deploy user
+          context.rbenv_global(ruby_version) do
+            user(deploy_user)
+          end
+
+          context.rbenv_script 'assets:precompile' do
+            code output[:assets_precompilation_command]
+            user deploy_user
+            cwd File.join(deploy_to, 'current')
+            group www_group
+            environment env
+          end
+        else
+          context.execute 'assets:precompile' do
+            command output[:assets_precompilation_command]
+            user node['deployer']['user']
+            cwd File.join(deploy_to, 'current')
+            group www_group
+            environment env
+          end
         end
       end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,6 +13,7 @@ depends 'deployer'
 depends 'chef_nginx'
 depends 'logrotate'
 depends 'ruby-ng'
+depends 'ruby_rbenv'
 
 supports 'amazon', '>= 2017.03'
 supports 'ubuntu', '>= 16.04'

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -29,35 +29,63 @@ end
 
 # Ruby and bundler
 include_recipe 'deployer'
-if node['platform_family'] == 'debian'
-  include_recipe 'ruby-ng::dev'
-else
-  ruby_pkg_version = node['ruby-ng']['ruby_version'].split('.')[0..1]
-  package "ruby#{ruby_pkg_version.join('')}"
-  package "ruby#{ruby_pkg_version.join('')}-devel"
-  execute "/usr/sbin/alternatives --set ruby /usr/bin/ruby#{ruby_pkg_version.join('.')}"
-end
 
-apt_repository 'apache2' do
-  uri 'http://ppa.launchpad.net/ondrej/apache2/ubuntu'
-  distribution node['lsb']['codename']
-  components %w[main]
-  keyserver 'keyserver.ubuntu.com'
-  key 'E5267A6C'
-  only_if { node['defaults']['webserver']['use_apache2_ppa'] }
-end
+# Install Ruby, either via rbenv or ng-ruby
+if node['rbenv']
+  # Install Ruby via rbenv
+  ruby_version = node['rbenv']['ruby_version']
+  deploy_user = node['deployer']['user'] || root
 
-gem_package 'bundler' do
-  action :install
-end
+  # Install rbenv for deploy user
+  rbenv_user_install(deploy_user)
 
-if node['platform_family'] == 'debian'
-  link '/usr/local/bin/bundle' do
-    to '/usr/bin/bundle'
+  # Install a specified ruby_version for deploy user
+  rbenv_ruby(ruby_version) do
+    user(deploy_user)
+  end
+
+  # Globally set ruby_version for deploy user
+  rbenv_global(ruby_version) do
+    user(deploy_user)
+  end
+
+  # rbenv aware bundler install
+  rbenv_gem 'bundler' do
+    user deploy_user
+    rbenv_version ruby_version
   end
 else
-  link '/usr/local/bin/bundle' do
-    to '/usr/local/bin/bundler'
+  # Install Ruby via ng-ruby
+  if node['platform_family'] == 'debian'
+    include_recipe 'ruby-ng::dev'
+  else
+    ruby_pkg_version = node['ruby-ng']['ruby_version'].split('.')[0..1]
+    package "ruby#{ruby_pkg_version.join('')}"
+    package "ruby#{ruby_pkg_version.join('')}-devel"
+    execute "/usr/sbin/alternatives --set ruby /usr/bin/ruby#{ruby_pkg_version.join('.')}"
+  end
+
+  apt_repository 'apache2' do
+    uri 'http://ppa.launchpad.net/ondrej/apache2/ubuntu'
+    distribution node['lsb']['codename']
+    components %w[main]
+    keyserver 'keyserver.ubuntu.com'
+    key 'E5267A6C'
+    only_if { node['defaults']['webserver']['use_apache2_ppa'] }
+  end
+
+  gem_package 'bundler' do
+    action :install
+  end
+
+  if node['platform_family'] == 'debian'
+    link '/usr/local/bin/bundle' do
+      to '/usr/bin/bundle'
+    end
+  else
+    link '/usr/local/bin/bundle' do
+      to '/usr/local/bin/bundler'
+    end
   end
 end
 

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -7,6 +7,13 @@
 
 prepare_recipe
 
+# Install additional packages set in configuration
+if node['additional_packages'] && node['additional_packages'].is_a?(Array)
+  node['additional_packages'].each do |package|
+    apt_package(package)
+  end
+end
+
 # Monit and cleanup
 if node['platform_family'] == 'debian'
   execute 'mkdir -p /etc/monit/conf.d'

--- a/templates/default/appserver.service.erb
+++ b/templates/default/appserver.service.erb
@@ -42,7 +42,16 @@ def different_gemfile?
 end
 
 def start_<%= @name %>
-  run_and_ignore_exitcode_and_print_command "cd #{ROOT_PATH}/current && /usr/local/bin/bundle exec <%= @command %>"
+  <%
+  # Check for rbenv in node object
+  # If it is set, we want to run bundle exec, without using the absolute path to the bundle exec
+  # If not, we proceed as normal
+  %>
+  <% if node['rbenv'] %>
+    run_and_ignore_exitcode_and_print_command "cd #{ROOT_PATH}/current && bundle exec <%= @command %>"
+  <% else %>
+    run_and_ignore_exitcode_and_print_command "cd #{ROOT_PATH}/current && /usr/local/bin/bundle exec <%= @command %>"
+  <% end %>
 end
 
 def stop_<%= @name %>


### PR DESCRIPTION
This PR includes all of the changes we've made to our fork of opsworks_ruby in order to get it working how we need it to with our servers.

The 2 main changes:
1. Adding support to install additional packages from the OpsWorks custom JSON
2. Adding support for rbenv to install and run ruby instead of ruby-ng