### PR TITLE
Customizing Nginx template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="1.8.1-watchtower"></a>
+# [1.8.1-watchtower](https://github.com/WatchTowerBenefits/opsworks_ruby/compare/v1.8.0-watchtower...v1.8.1-watchtower)
+
+### Features
+* Updating Nginx config template
+  * Adding `/health_check` location that does not force HTTPS, but turns on the proxy_ignore_client_abort flag to prevent the AWS ELB from prematurely closing connections
+  * Adding in code for the `/` location to force HTTPS. This was previously done through the Custom JSON for `['deploy']['webserver']['extra_config']`
+
 <a name="1.8.0-watchtower"></a>
 # [1.8.0-watchtower](https://github.com/WatchTowerBenefits/opsworks_ruby/compare/v1.8.0...v1.8.0-watchtower)
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ An example configuration for our `core_api` servers looks like:
       },
       "appserver": {
         "application_yml": true
-      },
-      "webserver": {
-        "_extra_config_comment": "Redirect HTTP Requests to HTTPS, unless it is the /health_check endpoint. (extraneous spacing preserves nginx conf file formatting)",
-        "extra_config": "set $redirect_to_https 0;\n  if ($http_x_forwarded_proto != 'https') { set $redirect_to_https 1; }\n  if ($request_uri = '/health_check') { set $redirect_to_https 0; }\n  if ($redirect_to_https = 1) { return 301 https://$host$request_uri; }"
       }
     }
   }
@@ -55,6 +51,12 @@ In order to install rbenv, with the Ruby version of your choice, add `node['rben
 Currently, rbenv support is implemented with Rails as the framework, and Puma as the app server.
 Due to this, if we end up using this recipe for another Ruby framework or we want to switch app servers, we will need to add in support for rbenv in those library files.
 We are currently using nginx as the web server, but no changes were made there, so switching web servers should be straightforward.
+
+### Nginx Configuration Chanages
+* Added a `/health_check` location for AWS ELB
+  * This location does not force HTTPS so the ELB can hit it via HTTP
+  * This location also turns on the `proxy_ignore_client_abort` flag in order to prevent the ELB from prematurely closing the connection 
+* Update the `/` location to force HTTPS
 
 ## Recipes
 This cookbook provides five main recipes, which should be attached to corresponding OpsWorks actions.

--- a/templates/default/appserver.nginx.conf.erb
+++ b/templates/default/appserver.nginx.conf.erb
@@ -19,7 +19,19 @@ server {
   keepalive_timeout <%= @out[:keepalive_timeout] || '15' %>;
   send_timeout <%= @out[:send_timeout] || '10' %>;
 
+  location /health_check {
+    # Prevent ELB health check from closing connections
+    proxy_ignore_client_abort on;
+
+    try_files $uri/index.html $uri/index.htm @puma;
+  }
+
   location / {
+    # If the request does not come through as https, redirect to https
+    if ($http_x_forwarded_proto != 'https') {
+      return 301 https://$host$request_uri;
+    }
+
     try_files $uri/index.html $uri/index.htm @<%= @name %>;
   }
 


### PR DESCRIPTION
Updating the Nginx template to include a /health_check location that will ignore proxy client aborts and not force HTTPS for the load balancer health checks. This allows us to handle the configuration here instead of trying to pass it in through OpsWorks custom JSON.

**Note:** This is already in place on Edge and Production, just wanted to make sure and get the changes committed as well.