### PR TITLE
Hutch worker deployment

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,5 +2,6 @@
 
 source 'https://supermarket.chef.io'
 solver :ruby, :required
+cookbook "seven_zip", "~> 2.0"
 
 metadata

--- a/libraries/drivers_worker_hutch.rb
+++ b/libraries/drivers_worker_hutch.rb
@@ -16,58 +16,12 @@ module Drivers
       end
       alias after_undeploy after_deploy
 
+      def shutdown
+        unmonitor_monit
+      end
+
       def process_count
         1
-      end
-
-      def restart_monit
-        return if ENV['TEST_KITCHEN'] # Don't like it, but we can't run multiple processes in Docker on travis
-
-        context.execute "monit restart hutch_#{app['shortname']}_worker" do
-          retries 3
-        end
-      end
-
-      def add_worker_monit
-        opts = {
-          application:      app['shortname'],
-          out:              out,
-          deploy_to:        deploy_dir(app),
-          environment:      environment,
-          adapter:          adapter,
-          app_shortname:    app['shortname'],
-          hutch_identifier: hutch_identifier,
-          hutch_pid_file:   hutch_pid_file,
-          hutch_shell_cmd:  hutch_shell_cmd,
-          executing_user:   user
-        }
-
-        context.template File.join(node['monit']['basedir'], "#{opts[:adapter]}_#{opts[:application]}.monitrc") do
-          mode('0640')
-          source("#{opts[:adapter]}.monitrc.erb")
-          variables(opts)
-        end
-
-        context.execute 'monit reload'
-      end
-
-      private
-
-      def hutch_identifier
-        "hutch_#{app['shortname']}_worker"
-      end
-
-      def hutch_pid_file
-        "/run/lock/#{app['shortname']}/#{hutch_identifier}.pid"
-      end
-
-      def executing_user
-        node['deployer']['user'] || context.root
-      end
-
-      def hutch_shell_cmd
-        env_info = environment.map {|k,v| "#{k}=\"#{v}\""}.join(' ')
-        "#{env_info} bundle exec hutch --autoload-rails --pidfile=#{hutch_pid_file}"
       end
     end
   end

--- a/libraries/drivers_worker_hutch.rb
+++ b/libraries/drivers_worker_hutch.rb
@@ -38,6 +38,7 @@ module Drivers
           app_shortname:    app['shortname'],
           hutch_identifier: hutch_identifier,
           hutch_pid_file:   hutch_pid_file,
+          hutch_shell_cmd:  hutch_shell_cmd,
           executing_user:   user
         }
 

--- a/libraries/drivers_worker_hutch.rb
+++ b/libraries/drivers_worker_hutch.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Drivers
+  module Worker
+    class Hutch < Drivers::Worker::Base
+      adapter :hutch
+      allowed_engines :hutch
+      output filter: %i[process_count syslog workers queues]
+      packages :monit
+
+      def configure
+        add_worker_monit
+      end
+
+      def after_deploy
+        restart_monit
+      end
+      alias after_undeploy after_deploy
+    end
+  end
+end

--- a/libraries/drivers_worker_hutch.rb
+++ b/libraries/drivers_worker_hutch.rb
@@ -3,10 +3,9 @@
 module Drivers
   module Worker
     class Hutch < Drivers::Worker::Base
-      adapter :hutch
-      allowed_engines :hutch
-      output filter: %i[process_count syslog workers queues]
-      packages :monit
+      adapter(:hutch)
+      allowed_engines(:hutch)
+      packages(:monit)
 
       def configure
         add_worker_monit
@@ -16,6 +15,59 @@ module Drivers
         restart_monit
       end
       alias after_undeploy after_deploy
+
+      def process_count
+        1
+      end
+
+      def restart_monit
+        return if ENV['TEST_KITCHEN'] # Don't like it, but we can't run multiple processes in Docker on travis
+
+        context.execute "monit restart hutch_#{app['shortname']}_worker" do
+          retries 3
+        end
+      end
+
+      def add_worker_monit
+        opts = {
+          application:      app['shortname'],
+          out:              out,
+          deploy_to:        deploy_dir(app),
+          environment:      environment,
+          adapter:          adapter,
+          app_shortname:    app['shortname'],
+          hutch_identifier: hutch_identifier,
+          hutch_pid_file:   hutch_pid_file,
+          executing_user:   user
+        }
+
+        context.template File.join(node['monit']['basedir'], "#{opts[:adapter]}_#{opts[:application]}.monitrc") do
+          mode('0640')
+          source("#{opts[:adapter]}.monitrc.erb")
+          variables(opts)
+        end
+
+        context.execute 'monit reload'
+      end
+
+      private
+
+      def hutch_identifier
+        "hutch_#{app['shortname']}_worker"
+      end
+
+      def hutch_pid_file
+        "/run/lock/#{app['shortname']}/#{hutch_identifier}.pid"
+      end
+
+      def executing_user
+        node['deployer']['user'] || context.root
+      end
+
+      def hutch_shell_cmd
+        env_info = environment.map {|k,v| "#{k}=\"#{v}\""}.join(' ')
+        "#{env_info} bundle exec hutch --autoload-rails --pidfile=#{hutch_pid_file}"
+      end
     end
   end
 end

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -27,11 +27,16 @@ every_enabled_application do |application|
     databases.push(Drivers::Db::Factory.build(self, application, rds: rds))
   end
 
-  scm = Drivers::Scm::Factory.build(self, application)
+  scm       = Drivers::Scm::Factory.build(self, application)
   framework = Drivers::Framework::Factory.build(self, application, databases: databases)
   appserver = Drivers::Appserver::Factory.build(self, application, databases: databases)
-  worker = Drivers::Worker::Factory.build(self, application, databases: databases)
+  worker    = Drivers::Worker::Factory.build(self, application, databases: databases)
   webserver = Drivers::Webserver::Factory.build(self, application)
+  items     = databases + [scm, framework, appserver, worker, webserver]
 
-  fire_hook(:configure, items: databases + [scm, framework, appserver, worker, webserver])
+  if node['hutch_server'] && node['hutch_server']['enabled']
+    items << Drivers::Worker::Hutch.new(self, application, databases: databases)
+  end
+
+  fire_hook(:configure, items: items)
 end

--- a/templates/default/hutch.monitrc.erb
+++ b/templates/default/hutch.monitrc.erb
@@ -1,11 +1,5 @@
-<% ([@out[:process_count].to_i || 1].max).times do |n| %>
-  <% identifier = "#{@application}-#{n+1}" %>
-  <% pid_file = "/run/lock/#{@app_shortname}/hutch_#{identifier}.pid" %>
-
-check process hutch_<%= identifier.to_s %>
-  with pidfile <%= pid_file.to_s %>
-  start program = "/bin/su - <%= node['deployer']['user'] %> -c 'cd <%= File.join(@deploy_to, 'current') %> && <%= @environment.map {|k,v| "#{k}=\"#{v}\""}.join(' ') %>  bundle exec hutch --pidfile=<%= pid_file.to_s %> '" with timeout 90 seconds
-  stop  program = "/bin/su - <%= node['deployer']['user'] %> -c 'kill -s TERM `cat <%= pid_file.to_s %>`'" with timeout 90 seconds
-  group hutch_<%= @application.to_s %>_group
-
-<% end %>
+check process <%= @hutch_identifier.to_s %>
+with pidfile <%= @hutch_pid_file.to_s %>
+start program = "/bin/su - <%= @executing_user %> -c 'cd <%= File.join(@deploy_to, 'current') %> && <%= @hutch_shell_cmd.to_s %> '" with timeout 90 seconds
+stop  program = "/bin/su - <%= @executing_user %> -c 'kill -s TERM `cat <%= @hutch_pid_file.to_s %>`'" with timeout 90 seconds
+group <%= @hutch_identifier.to_s %>_group

--- a/templates/default/hutch.monitrc.erb
+++ b/templates/default/hutch.monitrc.erb
@@ -1,0 +1,11 @@
+<% ([@out[:process_count].to_i || 1].max).times do |n| %>
+  <% identifier = "#{@application}-#{n+1}" %>
+  <% pid_file = "/run/lock/#{@app_shortname}/hutch_#{identifier}.pid" %>
+
+check process hutch_<%= identifier.to_s %>
+  with pidfile <%= pid_file.to_s %>
+  start program = "/bin/su - <%= node['deployer']['user'] %> -c 'cd <%= File.join(@deploy_to, 'current') %> && <%= @environment.map {|k,v| "#{k}=\"#{v}\""}.join(' ') %>  bundle exec hutch --pidfile=<%= pid_file.to_s %> '" with timeout 90 seconds
+  stop  program = "/bin/su - <%= node['deployer']['user'] %> -c 'kill -s TERM `cat <%= pid_file.to_s %>`'" with timeout 90 seconds
+  group hutch_<%= @application.to_s %>_group
+
+<% end %>

--- a/templates/default/hutch.monitrc.erb
+++ b/templates/default/hutch.monitrc.erb
@@ -4,7 +4,7 @@
 
 check process hutch_<%= identifier.to_s %>
 with pidfile <%= hutch_pidfile.to_s %>
-start program = "/bin/su - <%= node['deployer']['user'] %> -c 'cd <%= File.join(@deploy_to, 'current') %> && <%= @environment.map { |k, v| "#{k}=\"#{v}\"" }.join(' ') %> bundle exec hutch --verbose --pidfile <%= hutch_pidfile.to_s %> <%= syslog.to_s %>'" with timeout 90 seconds
+start program = "/bin/su - <%= node['deployer']['user'] %> -c 'cd <%= File.join(@deploy_to, 'current') %> && <%= @environment.map { |k, v| "#{k}=\"#{v}\"" }.join(' ') %> bundle exec hutch -d --pidfile <%= hutch_pidfile.to_s %> <%= syslog.to_s %>'" with timeout 90 seconds
 stop  program = "/bin/su - <%= node['deployer']['user'] %> -c 'kill -s TERM `cat <%= hutch_pidfile.to_s %>`'" with timeout 90 seconds
 group hutch_<%= @application.to_s %>_group
 

--- a/templates/default/hutch.monitrc.erb
+++ b/templates/default/hutch.monitrc.erb
@@ -1,5 +1,10 @@
-check process <%= @hutch_identifier.to_s %>
-with pidfile <%= @hutch_pid_file.to_s %>
-start program = "/bin/su - <%= @executing_user %> -c 'cd <%= File.join(@deploy_to, 'current') %> && <%= @hutch_shell_cmd.to_s %> '" with timeout 90 seconds
-stop  program = "/bin/su - <%= @executing_user %> -c 'kill -s TERM `cat <%= @hutch_pid_file.to_s %>`'" with timeout 90 seconds
-group <%= @hutch_identifier.to_s %>_group
+<% identifier    = "#{@application}-1" %>
+<% hutch_pidfile = "/run/lock/#{@app_shortname}/hutch_#{identifier}.pid" %>
+<% syslog = !!@out[:syslog] ? "2>&1 | logger -t hutch-#{identifier}" : '' %>
+
+check process hutch_<%= identifier.to_s %>
+with pidfile <%= hutch_pidfile.to_s %>
+start program = "/bin/su - <%= node['deployer']['user'] %> -c 'cd <%= File.join(@deploy_to, 'current') %> && <%= @environment.map { |k, v| "#{k}=\"#{v}\"" }.join(' ') %> bundle exec hutch --verbose --pidfile <%= hutch_pidfile.to_s %> <%= syslog.to_s %>'" with timeout 90 seconds
+stop  program = "/bin/su - <%= node['deployer']['user'] %> -c 'kill -s TERM `cat <%= hutch_pidfile.to_s %>`'" with timeout 90 seconds
+group hutch_<%= @application.to_s %>_group
+


### PR DESCRIPTION
After a long and hard trial and error, I finally figured it out. It doesn't look like much, but it was pure-hell trying to get this to work.

Here's what the utility server's custom json config for ops-works will look like:

```json
{
    "rbenv": {
        "ruby_version": "2.3.6"
    },
    "hutch_server": {
        "enabled": true
    },
    "additional_packages": [
        "libcurl3",
        "libcurl3-gnutls",
        "libcurl4-openssl-dev",
        "zlib1g-dev",
        "liblzma-dev",
        "imagemagick"
    ],
    "deploy": {
        "core_api": {
            "framework": {
                "assets_precompile": false
            },
            "appserver": {
                "adapter": null,
                "application_yml": true
            },
            "webserver": {
                "adapter": null
            },
            "worker": {
                "adapter": "sidekiq",
                "config": {
                    "verbose": false,
                    "logfile": "./log/sidekiq.log",
                    "concurrency": 5,
                    "queues": [
                        "default",
                        "email",
                        "project",
                        "product",
                        "document",
                        "smart_parser.pdf.images",
                        "smart_parser.pdf.json"
                    ]
                }
            }
        }
    }
}
```

### Todo

Get this merged in and fix up the features server for some final tests. And get an instance of the refactored TE RMQ instance running, along side the older one (so production is unaffected)