### PR TITLE
Bugfix: Revert Hutch config tie-in, for deployment on utility server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ docs/build/*
 vendor
 client.pem
 .chef.login
+*.tar.gz

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -27,16 +27,11 @@ every_enabled_application do |application|
     databases.push(Drivers::Db::Factory.build(self, application, rds: rds))
   end
 
-  scm       = Drivers::Scm::Factory.build(self, application)
+  scm = Drivers::Scm::Factory.build(self, application)
   framework = Drivers::Framework::Factory.build(self, application, databases: databases)
   appserver = Drivers::Appserver::Factory.build(self, application, databases: databases)
-  worker    = Drivers::Worker::Factory.build(self, application, databases: databases)
+  worker = Drivers::Worker::Factory.build(self, application, databases: databases)
   webserver = Drivers::Webserver::Factory.build(self, application)
-  items     = databases + [scm, framework, appserver, worker, webserver]
 
-  if node['hutch_server'] && node['hutch_server']['enabled']
-    items << Drivers::Worker::Hutch.new(self, application, databases: databases)
-  end
-
-  fire_hook(:configure, items: items)
+  fire_hook(:configure, items: databases + [scm, framework, appserver, worker, webserver])
 end

--- a/recipes/shutdown.rb
+++ b/recipes/shutdown.rb
@@ -13,17 +13,11 @@ every_enabled_application do |application|
     databases.push(Drivers::Db::Factory.build(self, application, rds: rds))
   end
 
-  scm       = Drivers::Scm::Factory.build(self, application)
+  scm = Drivers::Scm::Factory.build(self, application)
   framework = Drivers::Framework::Factory.build(self, application, databases: databases)
   appserver = Drivers::Appserver::Factory.build(self, application)
-  worker    = Drivers::Worker::Factory.build(self, application, databases: databases)
+  worker = Drivers::Worker::Factory.build(self, application, databases: databases)
   webserver = Drivers::Webserver::Factory.build(self, application)
-  items     = databases + [scm, framework, appserver, worker, webserver]
 
-  if node['hutch_server'] && node['hutch_server']['enabled']
-    items << Drivers::Worker::Hutch.new(self, application, databases: databases)
-  end
-
-
-  fire_hook(:shutdown, items: items)
+  fire_hook(:shutdown, items: databases + [scm, framework, appserver, worker, webserver])
 end


### PR DESCRIPTION
This hopefully fixes the Sidekiq and Hutch conflict when trying to run these two processes in combination.

As a result, this will require us to create a new "Layer" for each ops-works environment.

On the Sidekiq utility layer, we simply just need to revert it back to its original state (i.e remove hutch references and timeout)

For the Hutch Utility here's what I'm using as the custom json config:

```json
{
    "rbenv": {
        "ruby_version": "2.5.7"
    },
    "additional_packages": [
        "libcurl3",
        "libcurl3-gnutls",
        "libcurl4-openssl-dev",
        "zlib1g-dev",
        "liblzma-dev",
        "imagemagick"
    ],
    "deploy": {
        "core_api": {
            "framework": {
                "assets_precompile": false
            },
            "appserver": {
                "adapter": null,
                "application_yml": true
            },
            "webserver": {
                "adapter": null
            },
            "worker": {
                "adapter": "hutch"
            }
        }
    }
}
```

We're going to treat hutch as a worker "adapter"


---

Also, I've noticed the size of our cookbooks is wonkey... This is because every time we create a "new" cookbook, we keep recursively including prior cookbook zip archives. Hence the deletion of `cookbooks.tar.gz` and the updated `.gitignore`

There's no reason for this to be 13mb's 🤣